### PR TITLE
user-1 homework

### DIFF
--- a/workshop/1/h2/user-1/blog.k8s.yaml
+++ b/workshop/1/h2/user-1/blog.k8s.yaml
@@ -1,0 +1,267 @@
+apiVersion: "v1"
+data:
+  default.conf: "server {
+
+    \    listen       80;
+
+    \    location / {
+
+    \        # $http_host is the host name that users seen on the browser
+    URL
+
+    \        # and it equals to `HTTP_HOST` request header.
+
+    \        proxy_set_header Host $http_host;
+
+
+    \        # You have to change this according to your setup.
+
+    \        proxy_pass http://wordpress-service;
+
+
+    \        # Modify `Location` of 301 or 302 HTTP response, so
+
+    \        # that the browser will follow the correct location.
+
+    \        proxy_redirect ~^http://[^/]*/(.*) http://$http_host/$1;
+
+    \    }
+
+    }"
+kind: "ConfigMap"
+metadata:
+  name: "nginx-conf"
+---
+apiVersion: "v1"
+data:
+  fluent.conf: "<source>
+
+    \  type tail
+
+    \  path /logs/**/access.log
+
+    \  tag nginx.access
+
+    \  format nginx
+
+    </source>
+
+
+    <source>
+
+    \  @type tail
+
+    \  format /^(?<time>\\d{4}/\\d{2}/\\d{2} \\d{2}:\\d{2}:\\d{2})
+    \\[(?<log_level>\\w+)\\] (?<pid>\\d+).(?<tid>\\d+): (?<message>.*)$/
+
+    \  tag nginx.error
+
+    \  path /logs/**/error.log
+
+    </source>
+
+
+    <match nginx.access>
+
+    \  @type stdout
+
+    </match>
+
+
+    <match nginx.error>
+
+    \  @type stdout
+
+    </match>"
+kind: "ConfigMap"
+metadata:
+  name: "fluentd-conf"
+---
+apiVersion: "v1"
+kind: "Secret"
+metadata:
+  name: "db-secret"
+stringData:
+  MYSQL_DATABASE: "wordpress"
+  MYSQL_PASSWORD: "sserpdrow"
+  MYSQL_ROOT_PASSWORD: "wqpejmo3n cpmo248"
+  MYSQL_USER: "wordpress"
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  name: "mysql-service"
+spec:
+  externalIPs: []
+  ports:
+    - port: 3306
+  selector:
+    cdk8s.deployment: "blog-Database-f5b51dd5"
+  type: "ClusterIP"
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: "mysql-deployment"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cdk8s.deployment: "blog-Database-f5b51dd5"
+  template:
+    metadata:
+      labels:
+        cdk8s.deployment: "blog-Database-f5b51dd5"
+    spec:
+      containers:
+        - env:
+            - name: "MYSQL_DATABASE"
+              valueFrom:
+                secretKeyRef:
+                  key: "MYSQL_DATABASE"
+                  name: "db-secret"
+            - name: "MYSQL_USER"
+              valueFrom:
+                secretKeyRef:
+                  key: "MYSQL_USER"
+                  name: "db-secret"
+            - name: "MYSQL_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  key: "MYSQL_PASSWORD"
+                  name: "db-secret"
+            - name: "MYSQL_ROOT_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  key: "MYSQL_ROOT_PASSWORD"
+                  name: "db-secret"
+          image: "mysql:5.7.31"
+          imagePullPolicy: "Always"
+          name: "main"
+          ports: []
+          volumeMounts: []
+      volumes: []
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  name: "wordpress-service"
+spec:
+  externalIPs: []
+  ports:
+    - port: 80
+  selector:
+    cdk8s.deployment: "blog-Wordpress-a81832a4"
+  type: "ClusterIP"
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: "wordpress-deployment"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cdk8s.deployment: "blog-Wordpress-a81832a4"
+  template:
+    metadata:
+      labels:
+        cdk8s.deployment: "blog-Wordpress-a81832a4"
+    spec:
+      containers:
+        - env:
+            - name: "WORDPRESS_DB_HOST"
+              value: "mysql-service"
+            - name: "WORDPRESS_DB_USER"
+              valueFrom:
+                secretKeyRef:
+                  key: "MYSQL_USER"
+                  name: "db-secret"
+            - name: "WORDPRESS_DB_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  key: "MYSQL_PASSWORD"
+                  name: "db-secret"
+            - name: "WORDPRESS_DB_NAME"
+              valueFrom:
+                secretKeyRef:
+                  key: "MYSQL_DATABASE"
+                  name: "db-secret"
+          image: "wordpress:php7.2"
+          imagePullPolicy: "Always"
+          name: "main"
+          ports: []
+          volumeMounts: []
+      volumes: []
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  name: "nginx-service"
+spec:
+  externalIPs: []
+  ports:
+    - port: 80
+  selector:
+    cdk8s.deployment: "blog-Nginx-f6ab34c6"
+  type: "LoadBalancer"
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: "nginx"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cdk8s.deployment: "blog-Nginx-f6ab34c6"
+  template:
+    metadata:
+      labels:
+        cdk8s.deployment: "blog-Nginx-f6ab34c6"
+    spec:
+      containers:
+        - env: []
+          image: "nginx:stable"
+          imagePullPolicy: "Always"
+          name: "main"
+          ports: []
+          volumeMounts:
+            - mountPath: "/etc/nginx/conf.d"
+              name: "nginx-conf"
+              readOnly: true
+            - mountPath: "/var/log/nginx/pod-log-dir"
+              name: "log"
+        - env: []
+          image: "fluent/fluentd:v1.9-1"
+          imagePullPolicy: "Always"
+          name: "logger"
+          ports: []
+          volumeMounts:
+            - mountPath: "/fluentd/etc"
+              name: "fluentd-conf"
+              readOnly: true
+      volumes:
+        - configMap:
+            items:
+              - key: "default.conf"
+                path: "default.conf"
+            name: "nginx-conf"
+          name: "nginx-conf"
+        - emptyDir: {}
+          name: "log"
+        - configMap:
+            items:
+              - key: "fluent.conf"
+                path: "fluent.conf"
+            name: "fluentd-conf"
+          name: "fluentd-conf"
+---
+apiVersion: "networking.k8s.io/v1beta1"
+kind: "Ingress"
+metadata:
+  name: "ingress"
+spec:
+  backend:
+    serviceName: "nginx-service"
+    servicePort: 80


### PR DESCRIPTION
目前這個 yaml 檔是透過 [cdk8s](https://github.com/awslabs/cdk8s) 來產生, 我來描述一下使用心得

目前 `cdk8s` 有分 `L1` 跟 `L2` 的 API:

`L1` 較低階, 但基本上所有需求都能應付, 比較貼近寫 k8s 的 spec yaml

`L2` 提供封裝過後的 `L1` 的 API, 在寫法上更貼近開發者的思維, 但有幾項缺陷:
  * 不是所有 k8s component spec 都支援, 比方說 `PersistentVolumeClaim ` 或 `PersistentVolume` 等等...
  * 目前它 `Secret` component 只支援 `stringData`, 而不是 base64 之後的字串, 它可能不能支援原始 binary 資料
  * 目前不管是 `L1` 或是 `L2`, `cdk8s` 皆不支援 `Helm`

因此如果要用這項工具在 production 上, 建議使用 `L1` API

即使如此, `cdk8s` 這個 project 非常值得關注, 我們之後因該會導入到現有的 production 上, 對於以開發者為主的團隊, 在體驗上或是維護上, 都是一個不錯的優勢

可以參考這支[cdk8s 程式](https://github.com/luckily/srcmesh-homework-blog/blob/main/src/main.ts), 是這個 yaml 檔的 source code
 